### PR TITLE
Added support for line-dasharray

### DIFF
--- a/src/Line.js
+++ b/src/Line.js
@@ -11,8 +11,16 @@ export default function Line (props) {
       8
     )),
     strokeOpacity: expr(layer, "paint", "line-opacity"),
+    strokeDasharray: expr(layer, "paint", "line-dasharray"),
   };
   const sw = style.strokeWidth;
+  let cssStyle = `stroke: ${style.stroke};`
+  if (style.strokeOpacity) {
+    cssStyle += `stroke-opacity: ${style.strokeOpacity};`
+  }
+  if (style.strokeDasharray) {
+    cssStyle += `stroke-dasharray: ${style.strokeDasharray};`;
+  }
 
   return {
     element: "svg",
@@ -59,8 +67,7 @@ export default function Line (props) {
         element: "path",
         attributes: {
           key: "path",
-          style,
-          stroke: style.stroke,
+          style: cssStyle,
           d: "M0 20 L 20 0",
         }
       }

--- a/src/util.js
+++ b/src/util.js
@@ -46,7 +46,13 @@ export function exprHandler ({zoom}) {
     else if (typeof(input) === "object") {
       let expr;
       if (Array.isArray(input)) {
-        expr = expression.createExpression(input).value;
+        if (specItem.type === "array") {
+          // Special case: some properties are arrays, which should not be mistaken for expressions. It should be treated as a literal value.
+          return input;
+        }
+        else {
+          expr = expression.createExpression(input).value;
+        }
       }
       else {
         expr = styleFunction.createFunction(input, specItem);


### PR DESCRIPTION
Added support for [line-dasharray](https://maplibre.org/maplibre-gl-js-docs/style-spec/layers/#paint-line-line-dasharray) style for lines:
<img width="191" alt="image" src="https://user-images.githubusercontent.com/1782448/196029278-3954fb1b-5550-4e96-ad0f-a4a12942e2c7.png">

There's a tricky thing: it's an array so it was considered as an expression before, but such properties cannot be data-driven. It should be treated as a basic array instead.
Also, fixed a bug where the style attribute was rendered in HTML as "[object Object]" so opacity was ignored.